### PR TITLE
Fix URL leading to Hackerspaces wiki page

### DIFF
--- a/README
+++ b/README
@@ -2,6 +2,6 @@ LaTeX Beamer Sources for the Hackerspace Design Patterns
 
 This is the presentation shown at the 24th Chaos Communication Congress: “Volldampf voraus!” on December 27th 2007 in Berlin. http://events.ccc.de/congress/2007/Fahrplan/events/2133.en.html
 
-The first presentation was shown during the “Hackers on a Plane” tour in August 2007.  Since then some patterns were modified or extended.  Have a look at http://hackerspaces.org/wiki/Design_Patterns for more inspiration.
+The first presentation was shown during the “Hackers on a Plane” tour in August 2007.  Since then some patterns were modified or extended.  Have a look at https://wiki.hackerspaces.org/Design_Patterns for more inspiration.
 
 Feel free to use or translate these slides.  Send me a message when you added something new.


### PR DESCRIPTION
The wiki now seems to live on a subdomain.